### PR TITLE
fix: remove sourcemaps on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint-staged": "^11.0.0",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.4.3",
+    "source-map-loader": "^3.0.0",
     "ts-node": "^10.0.0",
     "ts-type-guards": "^0.7.0",
     "typescript": "^4.2.4",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -54,6 +54,18 @@ const config = (environment: unknown, options: { mode: string; env: unknown }): 
             loader: 'babel-loader',
           },
         },
+        {
+          test: /\.js$/,
+          enforce: 'pre',
+          use: [
+            {
+              loader: 'source-map-loader',
+              options: {
+                filterSourceMappingUrl: () => false,
+              },
+            },
+          ],
+        },
       ],
     },
     resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,6 +1898,11 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abab@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
+
 abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -7230,6 +7235,20 @@ socks@^2.6.1:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.0.tgz#f2a04ee2808ad01c774dea6b7d2639839f3b3049"
+  integrity sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==
+  dependencies:
+    abab "^2.0.5"
+    iconv-lite "^0.6.2"
+    source-map-js "^0.6.2"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
when building the dev-env the sourcemap-comments will now be removed
from the 3rd party packages as they always triggered warnings in the dev
console (as they could not be found)